### PR TITLE
Comparison and equality

### DIFF
--- a/src/main/php/math/BigFloat.class.php
+++ b/src/main/php/math/BigFloat.class.php
@@ -5,9 +5,10 @@ use lang\IllegalArgumentException;
 /**
  * A big float
  *
- * @see     xp://math.BigNum
- * @test    xp://net.xp_framework.unittest.math.BigFloatTest
- * @test    xp://net.xp_framework.unittest.math.BigIntAndFloatTest
+ * @see   math.BigNum
+ * @test  math.unittest.ComparisonTest
+ * @test  math.unittest.BigFloatTest
+ * @test  math.unittest.BigIntAndFloatTest
  */
 class BigFloat extends BigNum {
 

--- a/src/main/php/math/BigInt.class.php
+++ b/src/main/php/math/BigInt.class.php
@@ -5,9 +5,10 @@ use lang\IllegalArgumentException;
 /**
  * A big integer
  *
- * @see     xp://math.BigNum
- * @test    xp://net.xp_framework.unittest.math.BigIntTest
- * @test    xp://net.xp_framework.unittest.math.BigIntAndFloatTest
+ * @see   math.BigNum
+ * @test  math.unittest.ComparisonTest
+ * @test  math.unittest.BigIntTest
+ * @test  math.unittest.BigIntAndFloatTest
  */
 class BigInt extends BigNum {
 

--- a/src/main/php/math/BigNum.class.php
+++ b/src/main/php/math/BigNum.class.php
@@ -12,10 +12,11 @@ use lang\Value;
  * @ext      bcmath
  */
 abstract class BigNum implements Value {
+  private static $PRECISION;
   protected $num;
 
   static function __static() {
-    bcscale(ini_get('precision') ?: 14);
+    bcscale(self::$PRECISION= (int)(ini_get('precision') ?: 14));
   }
   
   /**
@@ -98,7 +99,7 @@ abstract class BigNum implements Value {
     return bccomp(
       $this->num,
       $other instanceof self ? $other->num : $other,
-      PHP_VERSION_ID >= 80000 ? $precision : $precision ?? bcscale(null)
+      $precision ?? self::$PRECISION
     );
   }
 
@@ -113,7 +114,7 @@ abstract class BigNum implements Value {
     return 0 === bccomp(
       $this->num,
       $other instanceof self ? $other->num : $other,
-      PHP_VERSION_ID >= 80000 ? $precision : $precision ?? bcscale(null)
+      $precision ?? self::$PRECISION
     );
   }
 }

--- a/src/main/php/math/BigNum.class.php
+++ b/src/main/php/math/BigNum.class.php
@@ -98,7 +98,7 @@ abstract class BigNum implements Value {
     return bccomp(
       $this->num,
       $other instanceof self ? $other->num : $other,
-      PHP_VERSION_ID >= 80000 ? $precision : $precision ?? bcscale()
+      PHP_VERSION_ID >= 80000 ? $precision : $precision ?? bcscale(null)
     );
   }
 
@@ -113,7 +113,7 @@ abstract class BigNum implements Value {
     return 0 === bccomp(
       $this->num,
       $other instanceof self ? $other->num : $other,
-      PHP_VERSION_ID >= 80000 ? $precision : $precision ?? bcscale()
+      PHP_VERSION_ID >= 80000 ? $precision : $precision ?? bcscale(null)
     );
   }
 }

--- a/src/main/php/math/BigNum.class.php
+++ b/src/main/php/math/BigNum.class.php
@@ -65,16 +65,18 @@ abstract class BigNum implements Value {
   public function doubleValue() { return (double)$this->num; }
 
   /** @return string */
-  public function __toString() { return $this->num; }
+  public function __toString() { return (string)$this->num; }
 
   /** @return string */
   public function toString() { return nameof($this).'('.$this->num.')'; }
 
   /** @return string */
-  public function hashCode() { return (string)$this->num; }
+  public function hashCode() { return 'B'.(string)$this->num; }
 
   /**
-   * Compare another value to this bignum
+   * Compare another value to this bignum. Only regards instances of
+   * the same class as equal. For comparison with arbitrary values,
+   * use `compare()` instead.
    *
    * @param  var $value
    * @return int
@@ -84,12 +86,34 @@ abstract class BigNum implements Value {
   }
 
   /**
-   * Returns whether another object is equal to this
+   * Compare another value to this bignum. Returns 1 if this number is larger
+   * than the given value, 0 if they are the same, and -1 if this number is
+   * smaller.
    *
-   * @param  var $value
+   * @param  self|int|float|string $other
+   * @param  ?int $precision
+   * @return int
+   */
+  public function compare($other, $precision= null) {
+    return bccomp(
+      $this->num,
+      $other instanceof self ? $other->num : $other,
+      PHP_VERSION_ID >= 80000 ? $precision : $precision ?? bcscale()
+    );
+  }
+
+  /**
+   * Returns whether another value is equal to this bignum.
+   *
+   * @param  self|int|float|string $other
+   * @param  ?int $precision
    * @return bool
    */
-  public function equals($value) {
-    return $value instanceof $this && 0 === bccomp($this->num, $value->num);
+  public function equals($other, $precision= null) {
+    return 0 === bccomp(
+      $this->num,
+      $other instanceof self ? $other->num : $other,
+      PHP_VERSION_ID >= 80000 ? $precision : $precision ?? bcscale()
+    );
   }
 }

--- a/src/test/php/math/unittest/ComparisonTest.class.php
+++ b/src/test/php/math/unittest/ComparisonTest.class.php
@@ -1,0 +1,61 @@
+<?php namespace math\unittest;
+
+use math\{BigInt, BigFloat};
+use unittest\{Assert, Values, Test};
+
+class ComparisonTest {
+
+  /** @return iterable */
+  private function integers() {
+    yield [1, 1, 0];
+    yield [1, 0, 1];
+    yield [1, 2, -1];
+    yield [1, 1.5, -1];
+    yield [1, -1.5, 1];
+    yield [1, PHP_INT_MIN, 1];
+    yield [1, PHP_INT_MAX, -1];
+    yield [1, '1', 0];
+    yield [1, '18446744073709551616', -1];
+    yield ['18446744073709551616', '18446744073709551616', 0];
+  }
+
+  /** @return iterable */
+  private function floats() {
+    yield [1.0, 1.0, 0];
+    yield [1.0, 0.0, 1];
+    yield [1.0, 2.0, -1];
+    yield [1.0, 1.5, -1];
+    yield [1.0, '12699025049277956096.22', -1];
+    yield ['12699025049277956096.22', '12699025049277956096.22', 0];
+  }
+
+  #[Test, Values('integers')]
+  public function compare_bigint($a, $b, $expected) {
+    Assert::equals($expected, (new BigInt($a))->compare($b));
+  }
+
+  #[Test]
+  public function compare_bigint_to_float_using_zero_precision() {
+    Assert::equals(0, (new BigInt(1))->compare(1.5, 0));
+  }
+
+  #[Test, Values('floats')]
+  public function compare_bigfloat($a, $b, $expected) {
+    Assert::equals($expected, (new BigFloat($a))->compare($b));
+  }
+
+  #[Test, Values([[0, 0], [1, 0], [2, 0], [3, -1]])]
+  public function compare_bigfloat_with_precision($precision, $expected) {
+    Assert::equals($expected, (new BigFloat(1.444))->compare(1.445, $precision));
+  }
+
+  #[Test, Values('integers')]
+  public function equals_bigint($a, $b, $expected) {
+    Assert::equals(0 === $expected, (new BigInt($a))->equals($b));
+  }
+
+  #[Test, Values('floats')]
+  public function equals_bigfloat($a, $b, $expected) {
+    Assert::equals(0 === $expected, (new BigFloat($a))->equals($b));
+  }
+}


### PR DESCRIPTION
Add `compare()` function accompanying `equals()` with optional precision argument.

## Before

```php
// Equality comparison
if (1 === $this->hi->shiftRight(49)->intValue()) { ... }

// The compareTo() method only works with BigInts
if ($this->lo->compareTo(new BigInt('9223372036854775807')) > 0) {
  return $this->lo->subtract0('18446744073709551616')->intValue();
} else {
  return $this->lo->intValue();
}
```

## After

```php
// Equality comparison
if ($this->hi->shiftRight(49)->equals(1)) { ... }

// The compare() method is liberal in what it accepts
if ($this->lo->compare('9223372036854775807') > 0) {
  return $this->lo->subtract0('18446744073709551616')->intValue();
} else {
  return $this->lo->intValue();
}
```
