### PR TITLE
Make Big(Int|Float)::power() consistent with IEEE 754 rules

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,12 @@ XP Math changelog
 
 ## ?.?.? / ????-??-??
 
+## 10.0.0 / ????-??-??
+
+* Merged PR #6: Make `Big(Int|Float)::power()` consistent with IEEE 754
+  rules, see issue #5.
+  (@thekid)
+
 ## 9.3.0 / 2024-03-24
 
 * Made compatible with XP 12 - @thekid

--- a/src/main/php/math/BigFloat.class.php
+++ b/src/main/php/math/BigFloat.class.php
@@ -78,6 +78,10 @@ class BigFloat extends BigNum {
    * @return math.BigNum
    */
   public function power($other) {
+    if (0 === bccomp($this->num, 0) && -1 === bccomp($other instanceof self ? $other->num : $other, 0)) {
+      throw new IllegalArgumentException('Negative power of zero');
+    }
+
     return new self(bcpow($this->num, $other instanceof self ? $other->num : $other));
   }
 

--- a/src/main/php/math/BigInt.class.php
+++ b/src/main/php/math/BigInt.class.php
@@ -169,11 +169,15 @@ class BigInt extends BigNum {
   /**
    * ^
    *
-   * @see     http://en.wikipedia.org/wiki/Exponentiation
+   * @see    http://en.wikipedia.org/wiki/Exponentiation
    * @param  math.BigNum|int|float|string $other
    * @return math.BigNum
    */
   public function power($other) {
+    if (0 === bccomp($this->num, 0) && -1 === bccomp($other instanceof self ? $other->num : $other, 0)) {
+      throw new IllegalArgumentException('Negative power of zero');
+    }
+
     if ($other instanceof self) {
       return new self(bcpow($this->num, $other->num));
     } else if (is_int($other)) {

--- a/src/test/php/math/unittest/BigFloatTest.class.php
+++ b/src/test/php/math/unittest/BigFloatTest.class.php
@@ -184,9 +184,9 @@ class BigFloatTest {
     Assert::equals(new BigFloat(1.0), (new BigFloat(0.0))->power(new BigFloat(0.0)));
   }
 
-  #[Test]
+  #[Test, Expect(IllegalArgumentException::class)]
   public function powerOfZeroNegative() {
-    Assert::equals(new BigFloat(0.0), (new BigFloat(0.0))->power(new BigFloat(-2)));
+    (new BigFloat(0.0))->power(new BigFloat(-2));
   }
 
   #[Test]

--- a/src/test/php/math/unittest/BigIntTest.class.php
+++ b/src/test/php/math/unittest/BigIntTest.class.php
@@ -239,9 +239,9 @@ class BigIntTest {
     Assert::equals(new BigInt(1), (new BigInt(0))->power(new BigInt(0)));
   }
 
-  #[Test]
+  #[Test, Expect(IllegalArgumentException::class)]
   public function powerOfZeroNegative() {
-    Assert::equals(new BigInt(0), (new BigInt(0))->power(new BigInt(-2)));
+    (new BigInt(0))->power(new BigInt(-2));
   }
 
   #[Test]


### PR DESCRIPTION
See https://github.com/xp-framework/math/issues/5, this makes the method align with how the `pow` function and the `**` operator in PHP 9.0 will behave, albeit using the `lang.IllegalArgumentException` class instead of the `DivisionByZeroError` for consistency with the rest of this library's methods.

⚠️ This is a BC break, earlier versions expected 0 as a result of this operation.